### PR TITLE
replace dhis2-sync profile with dhis2-sync-vaccine-tracker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-connector</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.6-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>opensrp-server-connector</name>
     <description>OpenSRP Server Connector module</description>
     <url>http://github.com/OpenSRP/opensrp-server-connector</url>
@@ -17,7 +17,7 @@
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
 		<spring.version>5.2.3.RELEASE</spring.version>
         <opensrp.api.version>1.0.6-SNAPSHOT</opensrp.api.version>
-        <opensrp.core.version>2.11.0-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.11.3-SNAPSHOT</opensrp.core.version>
         <powermock.version>2.0.5</powermock.version>
         <lombok.version>1.18.12</lombok.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-connector</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.5-SNAPSHOT</version>
+    <version>2.2.6-SNAPSHOT</version>
     <name>opensrp-server-connector</name>
     <description>OpenSRP Server Connector module</description>
     <url>http://github.com/OpenSRP/opensrp-server-connector</url>

--- a/src/main/java/org/opensrp/connector/dhis2/DHIS2SyncerListener.java
+++ b/src/main/java/org/opensrp/connector/dhis2/DHIS2SyncerListener.java
@@ -14,8 +14,10 @@ import org.smartregister.domain.Event;
 import org.opensrp.service.ClientService;
 import org.opensrp.service.EventService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+@Profile("dhis2-sync-vaccine-tracker")
 @Component
 public class DHIS2SyncerListener {
 	

--- a/src/main/java/org/opensrp/connector/dhis2/VaccinationTracker.java
+++ b/src/main/java/org/opensrp/connector/dhis2/VaccinationTracker.java
@@ -15,8 +15,10 @@ import org.smartregister.domain.Event;
 import org.smartregister.domain.Obs;
 import org.opensrp.service.ClientService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+@Profile("dhis2-sync-vaccine-tracker")
 @Service
 public class VaccinationTracker extends DHIS2Service {
 	

--- a/src/main/java/org/opensrp/connector/repository/couch/AllDHIS2Marker.java
+++ b/src/main/java/org/opensrp/connector/repository/couch/AllDHIS2Marker.java
@@ -12,15 +12,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
-@Profile("dhis2-sync")
+@Profile("dhis2-sync-vaccine-tracker")
 @Repository
 public class AllDHIS2Marker extends BaseRepository<DHIS2Marker> {
-	
+
 	@Autowired
 	protected AllDHIS2Marker(@Qualifier(AllConstants.OPENSRP_DATABASE_CONNECTOR) CouchDbConnector db) {
 		super(DHIS2Marker.class, db);
 	}
-	
+
 	@GenerateView
 	public List<DHIS2Marker> findByName(String name) {
 		return queryView("by_name", name);


### PR DESCRIPTION
Removing the dependency of dhis2-sync profile on couchdb .... the code has already been updated. This PR is to separate the profiles since they dont share functionality.