### PR TITLE
Security patch dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # opensrp-server-connector
-[![Build Status](https://travis-ci.org/OpenSRP/opensrp-server-connector.svg?branch=master)](https://travis-ci.org/OpenSRP/opensrp-server-connector) [![Coverage Status](https://coveralls.io/repos/github/OpenSRP/opensrp-server-connector/badge.svg?branch=master)](https://coveralls.io/github/OpenSRP/opensrp-server-connector?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/dbed2b587000412687c28ba18d9bc8ab)](https://www.codacy.com/app/OpenSRP/opensrp-server-connector?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=OpenSRP/opensrp-server-connector&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/OpenSRP/opensrp-server-connector.svg?branch=master)](https://travis-ci.org/OpenSRP/opensrp-server-connector) [![Coverage Status](https://coveralls.io/repos/github/OpenSRP/opensrp-server-connector/badge.svg?branch=master)](https://coveralls.io/github/OpenSRP/opensrp-server-connector?branch=master) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/03bd8f9cb9f941c6a922c3b474e8c589)](https://www.codacy.com/gh/opensrp/opensrp-server-connector/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=OpenSRP/opensrp-server-connector&amp;utm_campaign=Badge_Grade)
 
 Integration with external systems - OpenMRS (REST and Atomfeed), DHIS2, RapidPro
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-connector</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <name>opensrp-server-connector</name>
     <description>OpenSRP Server Connector module</description>
     <url>http://github.com/OpenSRP/opensrp-server-connector</url>
@@ -17,7 +17,7 @@
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
 		<spring.version>5.2.3.RELEASE</spring.version>
         <opensrp.api.version>1.0.6-SNAPSHOT</opensrp.api.version>
-        <opensrp.core.version>2.11.3-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.12.17-SNAPSHOT</opensrp.core.version>
         <powermock.version>2.0.5</powermock.version>
         <lombok.version>1.18.12</lombok.version>
 
@@ -99,16 +99,6 @@
             <version>3.18.1-GA</version>
         </dependency>
         <dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.14.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.14.0</version>
-		</dependency>
-        <dependency>
             <groupId>org.ict4h</groupId>
             <artifactId>atomfeed-client</artifactId>
             <version>1.9.1</version>
@@ -116,12 +106,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-ext-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
 		    <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
- Bump up artifact version to 2.3.2
- Update codacy badge url

**Migrate dependencies**
- Bouncy castle bcprov-jdk15on to 1.70
- Bouncy castle bcprov-ext-jdk15on to 1.70
- Remove Log4J dependencies
- Server core to 2.12.17